### PR TITLE
Updating Installation section with git clone and adding required dependencies to setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Welcome to dbt-excel, the revolutionary dbt adapter that combines the rigor of d
 - Runs blazingly fast queries thanks to duckdb running in the background, so you can have your cake and eat it too!
 - Monitor your data assets, collaborate on data models, and document your queries, all within Excel. Remember, if it's not in Excel, it's not worth doing!
 
+### **Installation**
+
+To install dbt-excel, just run the following command in your terminal:
+
+```bash
+python -m pip install dbt-excel
+```
+
 ### **Development Installation**
 
 This section details how to setup a local environment to develop this dbt adapter.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ Welcome to dbt-excel, the revolutionary dbt adapter that combines the rigor of d
 
 ### **Installation**
 
+Clone this repo to your local machine and change directory:
+
+```bash
+git@github.com:godatadriven/dbt-excel.git
+cd dbt-excel
+```
+
 To install dbt-excel, just run the following command in your terminal:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -13,21 +13,26 @@ Welcome to dbt-excel, the revolutionary dbt adapter that combines the rigor of d
 - Runs blazingly fast queries thanks to duckdb running in the background, so you can have your cake and eat it too!
 - Monitor your data assets, collaborate on data models, and document your queries, all within Excel. Remember, if it's not in Excel, it's not worth doing!
 
-### **Installation**
+### **Development Installation**
 
-Clone this repo to your local machine and change directory:
+This section details how to setup a local environment to develop this dbt adapter.
 
-```bash
-git@github.com:godatadriven/dbt-excel.git
-cd dbt-excel
-```
+1. Clone this repo to your local machine and change directory:
+    ```bash
+    git clone git@github.com:godatadriven/dbt-excel.git
+    cd dbt-excel
+    ```
 
-To install dbt-excel, just run the following command in your terminal:
+1. Create a virtual environment:
+    ```bash
+    python -m virtualenv .venv
+    source .venv/bin/activate
+    ```
 
-```bash
-python -m pip install dbt-excel
-```
-
+1. To install dbt-excel in editable mode, run the following command in your terminal:
+    ```bash
+    python -m pip install -e .
+    ```
 
 #### Profile setup
 


### PR DESCRIPTION
The `Installation` section in the README is missing the `git clone ...` command. Even after doing this the user will be prompted to pip install openpyxl and pyarrow when they run `dbt build` for the first time. We can avoid this by adding these modules to setup.py. Result is an `Installation` section that should work for everyone with a minimal number of steps and no "manual" requirements.