### PR TITLE
Better handling of generated files

### DIFF
--- a/dbt/adapters/excel/connections.py
+++ b/dbt/adapters/excel/connections.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
-from dbt.adapters.duckdb.connections import DuckDBConnectionManager
-from dbt.adapters.duckdb.connections import DuckDBCredentials
+from dbt.adapters.duckdb import DuckDBConnectionManager
+from dbt.adapters.duckdb import DuckDBCredentials
 
 
 @dataclass

--- a/dbt/adapters/excel/impl.py
+++ b/dbt/adapters/excel/impl.py
@@ -12,4 +12,4 @@ class ExcelAdapter(DuckDBAdapter):
     def output_excel(self, location):
         import pandas as pd
 
-        pd.read_parquet(location + ".parquet").to_excel(location)
+        pd.read_parquet(location.replace(".xlsx", ".parquet")).to_excel(location)

--- a/dbt/include/excel/macros/adapters.sql
+++ b/dbt/include/excel/macros/adapters.sql
@@ -11,7 +11,7 @@
 
   {% elif format == 'xlsx' %}
     {% set copy_to %}
-      copy {{ relation }} to '{{ location }}.parquet' (FORMAT 'parquet');
+      copy {{ relation }} to '{{ location.replace(".xlsx", ".parquet") }}' (FORMAT 'parquet');
     {% endset %}
 
   {% else %}

--- a/docs/jaffle_shop_with_dbt_excel/models/customers.sql
+++ b/docs/jaffle_shop_with_dbt_excel/models/customers.sql
@@ -2,7 +2,6 @@
 
 config(
   materialized='external',
-  location='./customers.xlsx',
   format="xlsx"
 )
 

--- a/tests/unit/test_connections.py
+++ b/tests/unit/test_connections.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 from botocore.credentials import Credentials
-from dbt.adapters.duckdb.connections import Attachment
+from dbt.adapters.duckdb.credentials import Attachment
 
 from dbt.adapters.excel.connections import ExcelCredentials
 


### PR DESCRIPTION
We see potential for `dbt-excel` to be used in educational contexts where the students are learning how to best use dbt, they may also be learning SQL. `dbt-excel` is conducive to this situation as there is no requirement for an external database, no need to handle any credentials and the outputted data can be viewed using Excel (which most students will have prior experience of).

Currently the generated `xlsx` file is saved in a directory as specified by the `location` parameter in the models config block. When teaching students the desired structure of a dbt project (staging/intermediate/marts layers etc.) this introduces some overhead as students need to customise the `location` parameter of each model to ensure the `xlsx` files are generated in the same directory as the `sql` files. This PR changes the default behaviour so `xlsx` files are saved in the same directory as `sql` files, a `location` parameter can still be passed to overwrite this behaviour, all other file formats are unaffected.

Before (without any customised `location` parameters), files are generated in the base directory:
![image](https://user-images.githubusercontent.com/14027534/235606756-77c996d5-6b34-4d99-98c2-a0a7baefe64e.png)

After, files are generated in the same directory as the `sql` file:
![image](https://user-images.githubusercontent.com/14027534/235606277-fd4f1c91-6f44-4575-a1eb-1f72c1feb2c2.png)
