### PR TITLE
Updating dbt-duckdb imports to fix CI pipeline

### DIFF
--- a/dbt/adapters/excel/connections.py
+++ b/dbt/adapters/excel/connections.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
-from dbt.adapters.duckdb.connections import DuckDBConnectionManager
-from dbt.adapters.duckdb.connections import DuckDBCredentials
+from dbt.adapters.duckdb import DuckDBConnectionManager
+from dbt.adapters.duckdb import DuckDBCredentials
 
 
 @dataclass

--- a/dbt/adapters/excel/relation.py
+++ b/dbt/adapters/excel/relation.py
@@ -1,54 +1,5 @@
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Any
-from typing import Optional
-from typing import Type
-
-import pandas as pd
-
-from dbt.adapters.base.relation import BaseRelation
-from dbt.adapters.base.relation import Self
-from dbt.contracts.graph.nodes import SourceDefinition
+from dbt.adapters.duckdb.relation import DuckDBRelation
 
 
-@dataclass(frozen=True, eq=False, repr=False)
-class ExcelRelation(BaseRelation):
-    external_location: Optional[str] = None
-
-    @classmethod
-    def create_from_source(cls: Type[Self], source: SourceDefinition, **kwargs: Any) -> Self:
-
-        if "external_location" in source.meta:
-            external_location = source.meta["external_location"]
-        elif "external_location" in source.source_meta:
-            external_location = source.source_meta["external_location"]
-        else:
-            external_location = None
-
-        if external_location is not None:
-            external_location = external_location.format(
-                schema=source.schema,
-                name=source.name,
-                identifier=source.identifier,
-            )
-            if external_location.endswith(".xlsx"):
-                excel_location = Path(external_location.strip("'"))
-                csv_location = (
-                    excel_location.parent / excel_location.stem / source.identifier
-                ).with_suffix(".csv")
-                csv_location.parent.mkdir(exist_ok=True)
-                pd.read_excel(excel_location, sheet_name=source.identifier).to_csv(
-                    csv_location, index=False
-                )
-                external_location = str(csv_location)
-            if "(" not in external_location and not external_location.startswith("'"):
-                external_location = f"'{external_location}'"
-            kwargs["external_location"] = external_location
-
-        return super().create_from_source(source, **kwargs)  # type: ignore
-
-    def render(self) -> str:
-        if self.external_location:
-            return self.external_location
-        else:
-            return super().render()
+class ExcelRelation(DuckDBRelation):
+    pass

--- a/dbt/adapters/excel/relation.py
+++ b/dbt/adapters/excel/relation.py
@@ -1,5 +1,47 @@
-from dbt.adapters.duckdb.relation import DuckDBRelation
+from dataclasses import dataclass
+from typing import Any
+from typing import Optional
+from typing import Type
+
+from .connections import ExcelConnectionManager
+from dbt.adapters.base.relation import BaseRelation
+from dbt.adapters.base.relation import Self
+from dbt.adapters.duckdb.utils import SourceConfig
+from dbt.contracts.graph.nodes import SourceDefinition
 
 
-class ExcelRelation(DuckDBRelation):
-    pass
+@dataclass(frozen=True, eq=False, repr=False)
+class ExcelRelation(BaseRelation):
+    external: Optional[str] = None
+
+    @classmethod
+    def create_from_source(cls: Type[Self], source: SourceDefinition, **kwargs: Any) -> Self:
+        source_config = SourceConfig.create(source)
+        # First check to see if a 'plugin' is defined in the meta argument for
+        # the source or its parent configuration, and if it is, use the environment
+        # associated with this run to get the name of the source that we should
+        # reference in the compiled model
+        if "plugin" in source_config.meta:
+            plugin_name = source_config.meta["plugin"]
+            source_name = ExcelConnectionManager.env().load_source(plugin_name, source_config)
+            kwargs["external"] = source_name
+        elif "external_location" in source_config.meta:
+            # Call str.format with the schema, name and identifier for the source so that they
+            # can be injected into the string; this helps reduce boilerplate when all
+            # of the tables in the source have a similar location based on their name
+            # and/or identifier.
+            ext_location = source_config.meta["external_location"].format(
+                **source_config.as_dict()
+            )
+            # If it's a function call or already has single quotes, don't add them
+            if "(" not in ext_location and not ext_location.startswith("'"):
+                ext_location = f"'{ext_location}'"
+            kwargs["external"] = ext_location
+
+        return super().create_from_source(source, **kwargs)  # type: ignore
+
+    def render(self) -> str:
+        if self.external:
+            return self.external
+        else:
+            return super().render()

--- a/tests/unit/test_connections.py
+++ b/tests/unit/test_connections.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 from botocore.credentials import Credentials
-from dbt.adapters.duckdb.connections import Attachment
+from dbt.adapters.duckdb.credentials import Attachment
 
 from dbt.adapters.excel.connections import ExcelCredentials
 


### PR DESCRIPTION
As part of #66 it was noticed that `tox` was failing to run. A manual trigger of the CI pipeline [here](https://github.com/godatadriven/dbt-excel/actions/runs/4862663762) also showed this behaviour. This is likely due to this [commit](https://github.com/jwills/dbt-duckdb/commit/3c15dcd4d75641e833b1a4bbeedd6979498fe1ab) in `dbt-duckdb` which was released as part of [v1.4.2](https://github.com/jwills/dbt-duckdb/releases/tag/1.4.2) last week. Our [`setup.py`](https://github.com/godatadriven/dbt-excel/blob/main/setup.py#L40) permits patch version upgrades of `dbt-duckdb`.

This PR updates the imports for `dbt-duckdb` to reflect the changes made in last weeks release.